### PR TITLE
*layers/+spacemacs/spacemacs-editing/packages.el: enhance the advice for dired sorting

### DIFF
--- a/core/core-configuration-layer.el
+++ b/core/core-configuration-layer.el
@@ -448,6 +448,8 @@ cache folder.")
 
 (autoload 'quelpa "quelpa")
 (autoload 'quelpa-checkout "quelpa")
+(defvar quelpa-upgrade-p)
+
 (defun configuration-layer//configure-quelpa ()
   "Configure `quelpa' package."
   (with-eval-after-load 'quelpa

--- a/doc/VIMUSERS.org
+++ b/doc/VIMUSERS.org
@@ -491,7 +491,7 @@ that is loaded at startup. Here is an example:
                                           gotham)))
 #+END_SRC
 
-All installed themes can be listed and chosen using the ~SPC T h~ key binding.
+All installed themes can be listed and chosen using the ~SPC T s~ key binding.
 
 *** Nohlsearch
 Spacemacs emulates the default vim behavior which highlights search results even

--- a/layers/+lang/ocaml/README.org
+++ b/layers/+lang/ocaml/README.org
@@ -4,7 +4,7 @@
 
 [[file:img/ocaml.png]]
 
-* Table of Contents                     :TOC_5_gh:noexport:
+* Table of Contents                                       :TOC_5_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]
@@ -94,6 +94,7 @@ variable =ocaml-format-on-save=, e.g.,
 | ~SPC m h h~ | Document the identifier under point                      |
 | ~SPC m h t~ | Highlight identifier under cursor and print its type     |
 | ~SPC m h T~ | Prompt for expression and show its type                  |
+| ~SPC m r c~ | Construct expression at hole (_) based on its type       |
 | ~SPC m r d~ | Case analyze the current enclosing                       |
 | ~SPC m t p~ | Dune run tests and promote.                              |
 | ~SPC m t P~ | Dune promote.                                            |

--- a/layers/+lang/ocaml/README.org
+++ b/layers/+lang/ocaml/README.org
@@ -4,7 +4,7 @@
 
 [[file:img/ocaml.png]]
 
-* Table of Contents                                       :TOC_5_gh:noexport:
+* Table of Contents                     :TOC_5_gh:noexport:
 - [[#description][Description]]
   - [[#features][Features:]]
 - [[#install][Install]]

--- a/layers/+lang/ocaml/packages.el
+++ b/layers/+lang/ocaml/packages.el
@@ -121,6 +121,7 @@
       "hh" 'merlin-document
       "ht" 'merlin-type-enclosing
       "hT" 'merlin-type-expr
+      "rc" 'merlin-construct
       "rd" 'merlin-destruct)
     (spacemacs/declare-prefix-for-mode 'tuareg-mode "mc" "compile/check")
     (spacemacs/declare-prefix-for-mode 'tuareg-mode "mE" "errors")

--- a/layers/+spacemacs/spacemacs-editing/packages.el
+++ b/layers/+spacemacs/spacemacs-editing/packages.el
@@ -116,11 +116,21 @@
     (define-advice dired-sort-toggle (:before ())
       "Recover `dired-actual-switches' with `dired-listing-switches' when long
       option \"--sort=...\" exists, and convert \"--sort=time\" to \"-t\"."
-      (when (string-match-p "--sort=" dired-actual-switches)
-        (setq dired-actual-switches
-              (concat dired-listing-switches
-                      (when (string-match-p "--sort=time" dired-actual-switches)
-                        " -t")))))))
+      (when-let (((string-match-p "--sort=" dired-actual-switches))
+                 (switches dired-listing-switches))
+        ;; ignore "-t" option first, determines it from actually switches later
+        (when (string-match "\\(\\`\\| \\)-\\([^t]*\\)\\(t\\)\\([^ ]*\\)"
+                            switches)
+          (let ((alone (and (equal (match-string 2 switches) "")
+                            (equal (match-string 4 switches) ""))))
+            ;; the 2nd and 4th are empty indicate it's standalone "-t"
+            ;; otherwise the option is in the "-XtY" format
+            (setq switches (replace-match "" t t switches
+                                          (unless alone 3)))))
+        ;; determines the "--sort=time" option and converts it to "-t" now
+        (let ((sort-time (string-match-p "--sort=time" dired-actual-switches)))
+          (setq dired-actual-switches
+                (concat switches (when sort-time " -t"))))))))
 
 (defun spacemacs-editing/init-drag-stuff ()
   (use-package drag-stuff

--- a/layers/+tools/shell/packages.el
+++ b/layers/+tools/shell/packages.el
@@ -126,7 +126,7 @@
 
     (require 'esh-var)
     (add-to-list 'eshell-variable-aliases-list
-                 `("PAGER" ,(lambda (_indices) "cat") t))
+                 `("PAGER" ,(lambda (&optional _indices _quoted) "cat") t))
 
     ;; support `em-smart'
     (when shell-enable-smart-eshell


### PR DESCRIPTION
Hi,

The original advice code works with default `dired-listing-switches` values ("-al"), 
but when customer setting `dired-listing-switches` with "-t" inside (eg: "-alt"), user had to press the `s` key TWICE in dired buffer to toggle the sort.
Here are the steps to reproduce the issue:
1. `(custom-set-variables '(dired-listing-switches "-alt"))`
2. touch `/tmp/a`; sleep 1; touch `/tmp/b`
3. `(dired "/tmp")`, files be showed "/tmp/a" first, then "/tmp/b" (the `dired-actual-switches` is `-alt --sort=version`).
4. press `s`, the order is sampe as step 3, (the `dired-actual-switches` is `-al` now)
5. press `s`, the files ordered by time  (the (the `dired-actual-switches` is `-al -t` now)
The key point is step3, 
With this patch, the `dired-actual-switches` will changed as:
3. ... will be more naturely, 
